### PR TITLE
Music-Bot the Beginning - Play & Stop

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,12 +18,16 @@ jar {
 
 repositories {
     mavenCentral()
+    maven {
+        url 'https://m2.dv8tion.net/releases'
+    }
 }
 
 dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.0'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.0'
     implementation("net.dv8tion:JDA:5.0.0-alpha.5")
+    implementation 'com.sedmelluq:lavaplayer:1.3.77'
 }
 
 test {

--- a/src/main/java/SlashyBot/Slashy.java
+++ b/src/main/java/SlashyBot/Slashy.java
@@ -2,9 +2,13 @@ package SlashyBot;
 
 import SlashyBot.commandManaging.CommandManager;
 import SlashyBot.commandManaging.listener.CommandListener;
+import SlashyBot.music.PlayerManager;
 import SlashyBot.threading.SavingThread;
 import SlashyBot.threading.ShutdownlistenerThread;
 import SlashyBot.threading.ThreadModel;
+import com.sedmelluq.discord.lavaplayer.player.AudioPlayerManager;
+import com.sedmelluq.discord.lavaplayer.player.DefaultAudioPlayerManager;
+import com.sedmelluq.discord.lavaplayer.source.AudioSourceManagers;
 import net.dv8tion.jda.api.OnlineStatus;
 import net.dv8tion.jda.api.sharding.DefaultShardManagerBuilder;
 import net.dv8tion.jda.api.sharding.ShardManager;
@@ -28,6 +32,9 @@ public class Slashy {
     private CommandManager commandManager;
     // Sammlung aller Threads die Laufen
     Set<ThreadModel> threads;
+    // AudioManager, welche den Musicstuff regeln soll
+    public AudioPlayerManager audioPlayerManager;
+    public PlayerManager playerManager;
 
     public static void main(String[] args) {
         // Wir müssen am Anfang den Bot instanziieren
@@ -43,9 +50,13 @@ public class Slashy {
         // Erzeuge die Selbstreferenz
         INSTANCE = this;
 
+        // Command Manager Starten
         this.commandManager = new CommandManager();
         System.out.println("CommandManager gestartet");
+        // ShardManager erstellen und einrichten
         this.shardManager = configureShardManager();
+        // Audiostuff hochfahren
+        audioStartup();
         System.out.println("Bot geht online");
         startup();
         System.out.println("Bot wurde eingerichtet");
@@ -60,7 +71,7 @@ public class Slashy {
 
         // * * * Einstellungen * * * //
         // Was macht er gerate
-        builder.setActivity(listening("Male Hentai ASMR"));
+        builder.setActivity(listening("to his own Rick Role"));
         // Onlinestatus
         builder.setStatus(OnlineStatus.ONLINE);
 
@@ -70,6 +81,18 @@ public class Slashy {
         // Build (Starten des Bots)
         return builder.build();
     }
+
+    // Startet und erstellt alle Klassen und Instanzen für die Audioverwaltung
+    private void audioStartup(){
+        // Audioplayer erstellen und registreiren
+        this.audioPlayerManager = new DefaultAudioPlayerManager();
+        AudioSourceManagers.registerRemoteSources(audioPlayerManager);
+
+        // neuen Playermanager erstellen
+        this.playerManager = new PlayerManager();
+    }
+
+
 
 
     // Richtet den Bot weiter ein (starten der Threads)

--- a/src/main/java/SlashyBot/commandManaging/CommandManager.java
+++ b/src/main/java/SlashyBot/commandManaging/CommandManager.java
@@ -4,6 +4,7 @@ import SlashyBot.commandManaging.commands.CultureCommand;
 import SlashyBot.commandManaging.commands.DeleteCommand;
 import SlashyBot.commandManaging.commands.PatPatCommand;
 import SlashyBot.commandManaging.commands.ServerCommand;
+import SlashyBot.music.commands.PlayCommand;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.TextChannel;
@@ -34,6 +35,9 @@ public class CommandManager {
         commands.put(DELETE, new DeleteCommand());
         commands.put(PATPAT, new PatPatCommand(counter.get("pats")));
         commands.put(CULTURE, new CultureCommand());
+
+        // Audio Commands
+        commands.put(PLAY, new PlayCommand());
     }
 
     private HashMap<String, Integer> loadCounterMap(){

--- a/src/main/java/SlashyBot/commandManaging/CommandManager.java
+++ b/src/main/java/SlashyBot/commandManaging/CommandManager.java
@@ -5,6 +5,7 @@ import SlashyBot.commandManaging.commands.DeleteCommand;
 import SlashyBot.commandManaging.commands.PatPatCommand;
 import SlashyBot.commandManaging.commands.ServerCommand;
 import SlashyBot.music.commands.PlayCommand;
+import SlashyBot.music.commands.StopCommand;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.TextChannel;
@@ -38,6 +39,7 @@ public class CommandManager {
 
         // Audio Commands
         commands.put(PLAY, new PlayCommand());
+        commands.put(STOP, new StopCommand());
     }
 
     private HashMap<String, Integer> loadCounterMap(){

--- a/src/main/java/SlashyBot/commandManaging/commands/CommandStringConstants.java
+++ b/src/main/java/SlashyBot/commandManaging/commands/CommandStringConstants.java
@@ -2,9 +2,17 @@ package SlashyBot.commandManaging.commands;
 
 public class CommandStringConstants {
 
+    // Präfix
     public static final String PREFIX = "//";
+
+    // Audiozeug
+    public static final String PLAY = "play";
+
+
+    // Random Zeug
     public static final String DELETE = "delete";
     public static final String PATPAT = "patpat";
     public static final String CULTURE = "culture";
+
 
 }

--- a/src/main/java/SlashyBot/commandManaging/commands/CommandStringConstants.java
+++ b/src/main/java/SlashyBot/commandManaging/commands/CommandStringConstants.java
@@ -7,6 +7,7 @@ public class CommandStringConstants {
 
     // Audiozeug
     public static final String PLAY = "play";
+    public static final String STOP = "stop";
 
 
     // Random Zeug

--- a/src/main/java/SlashyBot/music/AudioLoadResult.java
+++ b/src/main/java/SlashyBot/music/AudioLoadResult.java
@@ -16,23 +16,28 @@ public class AudioLoadResult implements AudioLoadResultHandler {
         this.controller = controller;
     }
 
+    // Wenn ein einziger Track angefragt wird
     @Override
     public void trackLoaded(AudioTrack track) {
+        // Überschreibt sofort die aktuelle wiedergabe
         controller.getPlayer().playTrack(track);
     }
 
+    // Wenn eine Playlist geladen wird
     @Override
     public void playlistLoaded(AudioPlaylist playlist) {
-
+        // To-Do
     }
 
+    // Wenn die Suche keine Ergebnisse liefert
     @Override
     public void noMatches() {
-
+        // To-Do: Fehlermeldung
     }
 
+    // Wenn das gesuchte nicht laden kann (Länderzugriffsverweigerung, etc.)
     @Override
     public void loadFailed(FriendlyException exception) {
-
+        // To-Do: Fehlermeldung
     }
 }

--- a/src/main/java/SlashyBot/music/AudioLoadResult.java
+++ b/src/main/java/SlashyBot/music/AudioLoadResult.java
@@ -1,0 +1,38 @@
+package SlashyBot.music;
+
+import com.sedmelluq.discord.lavaplayer.player.AudioLoadResultHandler;
+import com.sedmelluq.discord.lavaplayer.tools.FriendlyException;
+import com.sedmelluq.discord.lavaplayer.track.AudioPlaylist;
+import com.sedmelluq.discord.lavaplayer.track.AudioTrack;
+
+public class AudioLoadResult implements AudioLoadResultHandler {
+
+    private final String uri;
+    private final MusicController controller;
+
+
+    public AudioLoadResult(String uri, MusicController controller) {
+        this.uri = uri;
+        this.controller = controller;
+    }
+
+    @Override
+    public void trackLoaded(AudioTrack track) {
+        controller.getPlayer().playTrack(track);
+    }
+
+    @Override
+    public void playlistLoaded(AudioPlaylist playlist) {
+
+    }
+
+    @Override
+    public void noMatches() {
+
+    }
+
+    @Override
+    public void loadFailed(FriendlyException exception) {
+
+    }
+}

--- a/src/main/java/SlashyBot/music/AudioPlayerSendHandler.java
+++ b/src/main/java/SlashyBot/music/AudioPlayerSendHandler.java
@@ -1,0 +1,36 @@
+package SlashyBot.music;
+
+import com.sedmelluq.discord.lavaplayer.player.AudioPlayer;
+import com.sedmelluq.discord.lavaplayer.track.playback.AudioFrame;
+import java.nio.ByteBuffer;
+import net.dv8tion.jda.api.audio.AudioSendHandler;
+
+public class AudioPlayerSendHandler implements AudioSendHandler{
+
+    private final AudioPlayer audioPlayer;
+    private AudioFrame lastFrame;
+
+    // Konstructor für den Handler
+    public AudioPlayerSendHandler(AudioPlayer audioPlayer) {
+        this.audioPlayer = audioPlayer;
+    }
+
+    // Fragt ab, ob ein "Job zu tun ist"
+    @Override
+    public boolean canProvide() {
+        lastFrame = audioPlayer.provide();
+        return lastFrame != null;
+    }
+
+    // holt die Daten des lastFrames als ByteBuffer
+    @Override
+    public ByteBuffer provide20MsAudio() {
+        return ByteBuffer.wrap(lastFrame.getData());
+    }
+
+    // Lavaplayer unterstützt nur Opus
+    @Override
+    public boolean isOpus() {
+        return true;
+    }
+}

--- a/src/main/java/SlashyBot/music/MusicController.java
+++ b/src/main/java/SlashyBot/music/MusicController.java
@@ -1,0 +1,31 @@
+package SlashyBot.music;
+
+import SlashyBot.Slashy;
+import com.sedmelluq.discord.lavaplayer.player.AudioPlayer;
+import net.dv8tion.jda.api.entities.Guild;
+
+// ist eine Instanz eines MusicControllers (Darf immer nur einen Player haben)
+public class MusicController {
+
+    private Guild guild;
+    private AudioPlayer player;
+
+    public MusicController(Guild guild){
+        this.guild = guild;
+        this.player = Slashy.INSTANCE.audioPlayerManager.createPlayer();
+
+        this.guild.getAudioManager().setSendingHandler(new AudioPlayerSendHandler(player));
+        // Lautstärke ist von Haus aus sehr laut deswegen leiser
+        this.player.setVolume(10);
+    }
+
+    public Guild getGuild() {
+        return guild;
+    }
+
+    public AudioPlayer getPlayer() {
+        return player;
+    }
+
+
+}

--- a/src/main/java/SlashyBot/music/PlayerManager.java
+++ b/src/main/java/SlashyBot/music/PlayerManager.java
@@ -1,0 +1,33 @@
+package SlashyBot.music;
+
+import SlashyBot.Slashy;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+public class PlayerManager {
+
+    // Map in der alle Instanzen von Controllern mit ihren eigenen Player gespeichert werden
+    public ConcurrentMap<Long, MusicController> controller;
+
+    public PlayerManager() {
+        this.controller = new ConcurrentHashMap<Long, MusicController>();
+    }
+
+    public MusicController getController(long guildId){
+        // Rückgaber erstmal erzeugen
+        MusicController mc = null;
+
+        // Prüfen ob die ID existiert
+        if (this.controller.containsKey(guildId)){
+            // Wenn ja, wieder zurückgeben
+            mc = this.controller.get(guildId);
+            return mc;
+        }
+        // Wenn nein, neuen erstellen
+        mc = new MusicController(Slashy.INSTANCE.shardManager.getGuildById(guildId));
+        // Abspeichern
+        this.controller.put(guildId, mc);
+        // und zurück geben
+        return mc;
+    }
+}

--- a/src/main/java/SlashyBot/music/commands/PlayCommand.java
+++ b/src/main/java/SlashyBot/music/commands/PlayCommand.java
@@ -1,0 +1,83 @@
+package SlashyBot.music.commands;
+
+import SlashyBot.Slashy;
+import SlashyBot.commandManaging.commands.CommandStringConstants;
+import SlashyBot.commandManaging.commands.ServerCommand;
+import SlashyBot.music.AudioLoadResult;
+import SlashyBot.music.MusicController;
+import com.sedmelluq.discord.lavaplayer.player.AudioPlayerManager;
+import java.awt.Color;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.AudioChannel;
+import net.dv8tion.jda.api.entities.GuildVoiceState;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.TextChannel;
+import net.dv8tion.jda.api.managers.AudioManager;
+
+public class PlayCommand implements ServerCommand {
+    @Override
+    public void performCommand(Member member, TextChannel channel, Message message) {
+
+        // Den Command auseinandernehmen
+        String[] commandStringArr = message.getContentDisplay().split(" ");
+
+        // genug Argumente?
+        if (commandStringArr.length > 1){
+            // Checken, ist Auftragsteller überhaupt in einen Voice State hat
+            GuildVoiceState state;
+            if ((state = member.getVoiceState()) == null) {
+                // Fehlernachricht zurück geben
+                // Wenn nicht, einfach befehl abbrechen
+                return;
+            }
+
+            // Checken, ist Auftragsteller überhaupt in einem Voice Channel
+//            VoiceChannel voiceChannel;
+            AudioChannel audioChannel;
+            if ((audioChannel = state.getChannel()) == null){
+                EmbedBuilder builder = new EmbedBuilder();
+                builder.setDescription("Du kannst sowas nur machen, wenn du in einem Voicechannel bist");
+                builder.setColor(Color.RED);
+                channel.sendMessage("Error").setEmbeds(builder.build()).queue();
+                return;
+            }
+            // In welchem Channel ist er (Nachjoinen)
+            // Player setuppen
+            MusicController controller = Slashy.INSTANCE.playerManager.getController(audioChannel.getGuild().getIdLong());
+            AudioPlayerManager audioPlayerManager = Slashy.INSTANCE.audioPlayerManager;
+            AudioManager audioManager = audioChannel.getGuild().getAudioManager();
+            audioManager.openAudioConnection(audioChannel);
+
+            // Übergebene URL zusammensetzten
+            StringBuilder stringBuilder = new StringBuilder();
+            for (int i = 1; i < commandStringArr.length; i++) {
+                stringBuilder.append(commandStringArr[i])
+                    .append(" ");
+            }
+
+            // Wenn es nur Schlagworte sind, Youtubesuche
+            String url = stringBuilder.toString().trim();
+            if (!url.startsWith("http")) {
+                url = "ytsearch:" + url;
+            }
+
+            audioPlayerManager.loadItem(url, new AudioLoadResult(url, controller));
+            
+            System.out.println("Erfolgreich abgespielt");
+
+
+            return;
+        }
+
+        // Nicht genug
+        // Fehlernachricht zurück geben
+        EmbedBuilder builder = new EmbedBuilder();
+        builder.setDescription("Bitte benutze "
+            + CommandStringConstants.PREFIX
+            + CommandStringConstants.PLAY
+            + " <url>");
+        builder.setColor(Color.RED);
+        channel.sendMessage("Error").setEmbeds(builder.build()).queue();
+    }
+}

--- a/src/main/java/SlashyBot/music/commands/PlayCommand.java
+++ b/src/main/java/SlashyBot/music/commands/PlayCommand.java
@@ -62,11 +62,8 @@ public class PlayCommand implements ServerCommand {
                 url = "ytsearch:" + url;
             }
 
+            // Track laden
             audioPlayerManager.loadItem(url, new AudioLoadResult(url, controller));
-            
-            System.out.println("Erfolgreich abgespielt");
-
-
             return;
         }
 

--- a/src/main/java/SlashyBot/music/commands/StopCommand.java
+++ b/src/main/java/SlashyBot/music/commands/StopCommand.java
@@ -1,0 +1,56 @@
+package SlashyBot.music.commands;
+
+import SlashyBot.Slashy;
+import SlashyBot.commandManaging.commands.ServerCommand;
+import SlashyBot.music.AudioLoadResult;
+import SlashyBot.music.MusicController;
+import com.sedmelluq.discord.lavaplayer.player.AudioPlayer;
+import com.sedmelluq.discord.lavaplayer.player.AudioPlayerManager;
+import java.awt.Color;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.AudioChannel;
+import net.dv8tion.jda.api.entities.GuildVoiceState;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.TextChannel;
+import net.dv8tion.jda.api.managers.AudioManager;
+
+public class StopCommand implements ServerCommand {
+
+    @Override
+    public void performCommand(Member member, TextChannel channel, Message message) {
+        // Checken, ist Auftragsteller überhaupt in einen Voice State hat
+        GuildVoiceState state;
+        if ((state = member.getVoiceState()) == null) {
+            // Fehlernachricht zurück geben
+            // Wenn nicht, einfach befehl abbrechen
+            return;
+        }
+
+        // Checken, ist Auftragsteller überhaupt in einem Voice Channel
+        AudioChannel audioChannel;
+        if ((audioChannel = state.getChannel()) == null){
+            EmbedBuilder builder = new EmbedBuilder();
+            builder.setDescription("Du kannst sowas nur machen, wenn du in einem Voicechannel bist");
+            builder.setColor(Color.RED);
+            channel.sendMessage("Error").setEmbeds(builder.build()).queue();
+            return;
+        }
+        // In welchem Channel ist er (Nachjoinen)
+        // Player holen zum stoppen
+        MusicController controller = Slashy.INSTANCE.playerManager.getController(audioChannel.getGuild().getIdLong());
+        AudioManager audioManager = audioChannel.getGuild().getAudioManager();
+        AudioPlayer player = controller.getPlayer();
+
+        // Audio anhalten
+        player.stopTrack();
+        // Connection beenden
+        audioManager.closeAudioConnection();
+        // Abschiedsnachricht
+        message.addReaction("U+1F44C").queue();
+
+        System.out.println("Erfolgreich gestoppt");
+
+        return;
+    }
+}

--- a/src/main/java/SlashyBot/music/commands/StopCommand.java
+++ b/src/main/java/SlashyBot/music/commands/StopCommand.java
@@ -48,9 +48,5 @@ public class StopCommand implements ServerCommand {
         audioManager.closeAudioConnection();
         // Abschiedsnachricht
         message.addReaction("U+1F44C").queue();
-
-        System.out.println("Erfolgreich gestoppt");
-
-        return;
     }
 }


### PR DESCRIPTION
# Music-Bot the Beginning
Slashy hat nun die ersten primitiven Möglichkeiten Musik auf Youtube zu suchen und abzuspielen
### Momentan implementiert:
- `//play <url>`: Der Bot liest die übergebene Youtube URL aus, läd das entsprechende Lied und spielt es ab
  - es wir jegliche Wiedergabe zu dem Zeitpunkt abgebrochen und durch das neue Lied ersetzt (keine Queue)
- `//stop`: Beendet die Wiedergabe des Bots und lässt ihn den Channel verlassen
Die Befehle lassen sich nur benutzen, wenn man selbst in einem Voice-Channel ist
## Ausblick
Was auf jedenfall noch fehlt ist das hinzufügen von Playlisten, das Queuen von Liedern (also dass sie nicht direkt ersetzt werden) und das zeigen der Queue.
Später kommen vielleicht noch ein paar Komfortänderungen dazu. Sowas wie Pausieren, aber ohne die Queue zu löschen, Skippen von Liedern oder das shufflen einer Playlist