### PR TITLE
Music-Bot Queuesystem

### DIFF
--- a/src/main/java/SlashyBot/commandManaging/CommandManager.java
+++ b/src/main/java/SlashyBot/commandManaging/CommandManager.java
@@ -5,6 +5,8 @@ import SlashyBot.commandManaging.commands.DeleteCommand;
 import SlashyBot.commandManaging.commands.PatPatCommand;
 import SlashyBot.commandManaging.commands.ServerCommand;
 import SlashyBot.music.commands.PlayCommand;
+import SlashyBot.music.commands.ShuffleCommand;
+import SlashyBot.music.commands.SkipCommand;
 import SlashyBot.music.commands.StopCommand;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Message;
@@ -40,6 +42,8 @@ public class CommandManager {
         // Audio Commands
         commands.put(PLAY, new PlayCommand());
         commands.put(STOP, new StopCommand());
+        commands.put(SKIP, new SkipCommand());
+        commands.put(SHUFFLE, new ShuffleCommand());
     }
 
     private HashMap<String, Integer> loadCounterMap(){

--- a/src/main/java/SlashyBot/commandManaging/commands/CommandStringConstants.java
+++ b/src/main/java/SlashyBot/commandManaging/commands/CommandStringConstants.java
@@ -8,6 +8,8 @@ public class CommandStringConstants {
     // Audiozeug
     public static final String PLAY = "play";
     public static final String STOP = "stop";
+    public static final String SKIP = "skip";
+    public static final String SHUFFLE = "shuffle";
 
 
     // Random Zeug

--- a/src/main/java/SlashyBot/music/AudioLoadResult.java
+++ b/src/main/java/SlashyBot/music/AudioLoadResult.java
@@ -19,11 +19,24 @@ public class AudioLoadResult implements AudioLoadResultHandler {
     // Wenn ein einziger Track angefragt wird
     @Override
     public void trackLoaded(AudioTrack track) {
+
+        // Überprüfen ob der Player schon läuft. Dann nur queuen
+        if (controller.isCurentlyPlaying()){
+            Queue queue = controller.getTrackqueue();
+            queue.enqueue(track);
+
+            // Debugging
+            System.out.println("Es ein Lied enqueued");
+
+            return;
+        }
+
+
         // Überschreibt sofort die aktuelle Wiedergabe
         controller.getPlayer().playTrack(track);
 
         // Debugging
-        System.out.println("Es wurde ein einzelnes Lied gequeued");
+        System.out.println("Es ein neues Lied/Wiedergabe gestarted");
     }
 
     // Wenn eine Playlist geladen wird

--- a/src/main/java/SlashyBot/music/AudioLoadResult.java
+++ b/src/main/java/SlashyBot/music/AudioLoadResult.java
@@ -19,14 +19,32 @@ public class AudioLoadResult implements AudioLoadResultHandler {
     // Wenn ein einziger Track angefragt wird
     @Override
     public void trackLoaded(AudioTrack track) {
-        // Überschreibt sofort die aktuelle wiedergabe
+        // Überschreibt sofort die aktuelle Wiedergabe
         controller.getPlayer().playTrack(track);
+
+        // Debugging
+        System.out.println("Es wurde ein einzelnes Lied gequeued");
     }
 
     // Wenn eine Playlist geladen wird
     @Override
     public void playlistLoaded(AudioPlaylist playlist) {
-        // To-Do
+        Queue queue = controller.getTrackqueue();
+
+        // Darf nur direkter Link sein, keine Suche. Nimmt sonst einfach erstes
+        if (uri.startsWith("ytsearch: ")) {
+            queue.enqueue(playlist.getTracks().get(0));
+            return;
+        }
+
+        int trackcount = 0;
+        for (AudioTrack track : playlist.getTracks()) {
+            queue.enqueue(track);
+            trackcount++;
+        }
+
+        // Debugging
+        System.out.println("Es wurden " + trackcount + " Lieder geladen");
     }
 
     // Wenn die Suche keine Ergebnisse liefert

--- a/src/main/java/SlashyBot/music/MusicController.java
+++ b/src/main/java/SlashyBot/music/MusicController.java
@@ -10,11 +10,19 @@ public class MusicController {
     private Guild guild;
     private AudioPlayer player;
 
+    private Queue trackqueue;
+
     public MusicController(Guild guild){
         this.guild = guild;
         this.player = Slashy.INSTANCE.audioPlayerManager.createPlayer();
+        this.trackqueue = new Queue(this);
 
+        // AudioManager erstellen
         this.guild.getAudioManager().setSendingHandler(new AudioPlayerSendHandler(player));
+
+        // Neuen Eventlistener hinzufügen (registriert anfang und Ende der Tracks)
+        this.player.addListener(new TrackScheduler());
+
         // Lautstärke ist von Haus aus sehr laut deswegen leiser
         this.player.setVolume(10);
     }
@@ -27,5 +35,11 @@ public class MusicController {
         return player;
     }
 
+    public Queue getTrackqueue() {
+        return trackqueue;
+    }
 
+    public void clearQueue(){
+        this.trackqueue.clearQueue();
+    }
 }

--- a/src/main/java/SlashyBot/music/MusicController.java
+++ b/src/main/java/SlashyBot/music/MusicController.java
@@ -10,6 +10,8 @@ public class MusicController {
     private Guild guild;
     private AudioPlayer player;
 
+    private boolean playingstatus;
+
     private Queue trackqueue;
 
     public MusicController(Guild guild){
@@ -25,6 +27,9 @@ public class MusicController {
 
         // Lautstärke ist von Haus aus sehr laut deswegen leiser
         this.player.setVolume(10);
+
+        // Es spielt noch nichts
+        this.playingstatus = false;
     }
 
     public Guild getGuild() {
@@ -41,5 +46,18 @@ public class MusicController {
 
     public void clearQueue(){
         this.trackqueue.clearQueue();
+    }
+
+    public void setIsPlaying(){
+        System.out.println("Liste hat wieder einen Eintrag");
+        this.playingstatus = true;
+    }
+    public void playingStopped(){
+        System.out.println("Wiedergabeliste ist leer gelaufen");
+        this.playingstatus = false;
+    }
+
+    public boolean isCurentlyPlaying() {
+        return playingstatus;
     }
 }

--- a/src/main/java/SlashyBot/music/PlayerManager.java
+++ b/src/main/java/SlashyBot/music/PlayerManager.java
@@ -30,4 +30,18 @@ public class PlayerManager {
         // und zurück geben
         return mc;
     }
+
+
+
+    // eine Guild mit einer Id holen
+    public long getGuildByPlayerHash(int hash) {
+        for (MusicController controller : this.controller.values()) {
+            if (controller.getPlayer().hashCode() == hash){
+                return controller.getGuild().getIdLong();
+            }
+        }
+
+        // Fehler: Keinen Player gefunden
+        return -1;
+    }
 }

--- a/src/main/java/SlashyBot/music/Queue.java
+++ b/src/main/java/SlashyBot/music/Queue.java
@@ -62,6 +62,10 @@ public class Queue {
         this.queueList.clear();
     }
 
+    // Würfelt die Liste durch
+    public void shuffle() {
+        Collections.shuffle(queueList);
+    }
 
 
 

--- a/src/main/java/SlashyBot/music/Queue.java
+++ b/src/main/java/SlashyBot/music/Queue.java
@@ -25,6 +25,7 @@ public class Queue {
 
         // Gucken ob die Queue leer ist
         if (this.queueList.size() < 1) {
+            controller.playingStopped();
             return false;
         }
 
@@ -53,6 +54,7 @@ public class Queue {
 
         // Wenn noch nichts abspielt, Player starten
         if (controller.getPlayer().getPlayingTrack() == null){
+            controller.setIsPlaying();
             next();
         }
     }

--- a/src/main/java/SlashyBot/music/Queue.java
+++ b/src/main/java/SlashyBot/music/Queue.java
@@ -1,0 +1,85 @@
+package SlashyBot.music;
+
+import com.sedmelluq.discord.lavaplayer.player.AudioPlayer;
+import com.sedmelluq.discord.lavaplayer.track.AudioTrack;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class Queue {
+
+    private List<AudioTrack> queueList;
+    private MusicController controller;
+
+
+    public Queue(MusicController controller) {
+        this.controller = controller;
+        this.queueList = new ArrayList<AudioTrack>();
+    }
+
+    // Geht in der Queue eins weiter
+    public boolean next() {
+        // Debugging
+        System.out.println("Next Track will be played. Queue size = " + this.queueList.size());
+
+
+        // Gucken ob die Queue leer ist
+        if (this.queueList.size() < 1) {
+            return false;
+        }
+
+        // Die Queue ist nicht leer
+        // Den neuen track laden und aus der Liste löschen
+        AudioTrack track = queueList.remove(0);
+
+        // wenn der Track nicht leer ist, wird er abgespielt
+        if (track != null) {
+            this.controller.getPlayer().playTrack(track);
+            return true;
+        }
+
+        // Sonstige Fehler
+        return false;
+    }
+
+
+    // Fügt der Queue einen weiteren Track hinzu
+    public void enqueue(AudioTrack track) {
+        // Track der Queue hinzufügen
+        this.queueList.add(track);
+
+        // Debugging
+        System.out.println("Es wurde enqueued. Die Queue ist jetzt " + this.queueList.size() + " lang");
+
+        // Wenn noch nichts abspielt, Player starten
+        if (controller.getPlayer().getPlayingTrack() == null){
+            next();
+        }
+    }
+
+    // Löscht alle Einträge in der Queue
+    public void clearQueue() {
+        this.queueList.clear();
+    }
+
+
+
+
+    public List<AudioTrack> getQueueList() {
+        return queueList;
+    }
+
+    public void setQueueList(List<AudioTrack> queueList) {
+        this.queueList = queueList;
+    }
+
+    public MusicController getController() {
+        return controller;
+    }
+
+    public void setController(MusicController controller) {
+        this.controller = controller;
+    }
+
+
+}

--- a/src/main/java/SlashyBot/music/TrackScheduler.java
+++ b/src/main/java/SlashyBot/music/TrackScheduler.java
@@ -1,0 +1,55 @@
+package SlashyBot.music;
+
+import SlashyBot.Slashy;
+import com.sedmelluq.discord.lavaplayer.player.AudioPlayer;
+import com.sedmelluq.discord.lavaplayer.player.event.AudioEventAdapter;
+import com.sedmelluq.discord.lavaplayer.track.AudioTrack;
+import com.sedmelluq.discord.lavaplayer.track.AudioTrackEndReason;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.managers.AudioManager;
+
+public class TrackScheduler extends AudioEventAdapter {
+
+    @Override
+    public void onTrackStart(AudioPlayer player, AudioTrack track) {
+        // Debugging
+        System.out.println("Track started. Name: " + track.getInfo());
+
+        // Id der Guild holen
+        long guildid = Slashy.INSTANCE.playerManager.getGuildByPlayerHash(player.hashCode());
+        // Guild mit dieser Id holen
+        Guild guild = Slashy.INSTANCE.shardManager.getGuildById(guildid);
+
+    }
+
+    @Override
+    public void onTrackEnd(AudioPlayer player, AudioTrack track, AudioTrackEndReason endReason) {
+        // Debugging
+        System.out.println("Track ended");
+        
+        // Id der Guild holen
+        long guildid = Slashy.INSTANCE.playerManager.getGuildByPlayerHash(player.hashCode());
+        // Guild mit dieser Id holen
+        Guild guild = Slashy.INSTANCE.shardManager.getGuildById(guildid);
+
+        MusicController controller = Slashy.INSTANCE.playerManager.getController(guildid);
+        Queue queue = controller.getTrackqueue();
+//        if (endReason.mayStartNext) { // wurde im Video gezeigt, funzt aber nicht mit skip
+        if (queue.getQueueList().size() != 0) {
+            
+
+            // Debugging
+            System.out.println("Ein Track wurde gerade beendet und der nächste gestartet");
+
+            // Ist noch etwas in der Queue, dann abspielen
+            if (queue.next()) {
+                return;
+            }
+        }
+
+        // Es ist nichts mehr in der Queue, player beenden
+        AudioManager manager = guild.getAudioManager();
+        player.stopTrack();
+        manager.closeAudioConnection();
+    }
+}

--- a/src/main/java/SlashyBot/music/commands/PlayCommand.java
+++ b/src/main/java/SlashyBot/music/commands/PlayCommand.java
@@ -47,7 +47,12 @@ public class PlayCommand implements ServerCommand {
             MusicController controller = Slashy.INSTANCE.playerManager.getController(audioChannel.getGuild().getIdLong());
             AudioPlayerManager audioPlayerManager = Slashy.INSTANCE.audioPlayerManager;
             AudioManager audioManager = audioChannel.getGuild().getAudioManager();
-            audioManager.openAudioConnection(audioChannel);
+
+            // Dem VoiceChannel joinen falls nicht conneted
+            if (!audioManager.isConnected()){
+                System.out.println("Es gab noch keine Verbindung");
+                audioManager.openAudioConnection(audioChannel);
+            }
 
             // Übergebene URL zusammensetzten
             StringBuilder stringBuilder = new StringBuilder();
@@ -64,6 +69,9 @@ public class PlayCommand implements ServerCommand {
 
             // Track laden
             audioPlayerManager.loadItem(url, new AudioLoadResult(url, controller));
+
+            // Dem Controller sagen, dass er was spielt
+            controller.setIsPlaying();
             return;
         }
 

--- a/src/main/java/SlashyBot/music/commands/ShuffleCommand.java
+++ b/src/main/java/SlashyBot/music/commands/ShuffleCommand.java
@@ -33,7 +33,6 @@ public class ShuffleCommand implements ServerCommand {
             channel.sendMessage("Error").setEmbeds(builder.build()).queue();
             return;
         }
-        // In welchem Channel ist er (Nachjoinen)
         // Queue des Controllers holen und durchmischeln
         MusicController controller = Slashy.INSTANCE.playerManager.getController(audioChannel.getGuild().getIdLong());
         

--- a/src/main/java/SlashyBot/music/commands/ShuffleCommand.java
+++ b/src/main/java/SlashyBot/music/commands/ShuffleCommand.java
@@ -1,0 +1,49 @@
+package SlashyBot.music.commands;
+
+import SlashyBot.Slashy;
+import SlashyBot.commandManaging.commands.ServerCommand;
+import SlashyBot.music.MusicController;
+import com.sedmelluq.discord.lavaplayer.player.AudioPlayer;
+import java.awt.Color;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.AudioChannel;
+import net.dv8tion.jda.api.entities.GuildVoiceState;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.TextChannel;
+import net.dv8tion.jda.api.managers.AudioManager;
+
+public class ShuffleCommand implements ServerCommand {
+    @Override
+    public void performCommand(Member member, TextChannel channel, Message message) {
+        // Checken, ist Auftragsteller überhaupt in einen Voice State hat
+        GuildVoiceState state;
+        if ((state = member.getVoiceState()) == null) {
+            // Fehlernachricht zurück geben
+            // Wenn nicht, einfach befehl abbrechen
+            return;
+        }
+
+        // Checken, ist Auftragsteller überhaupt in einem Voice Channel
+        AudioChannel audioChannel;
+        if ((audioChannel = state.getChannel()) == null){
+            EmbedBuilder builder = new EmbedBuilder();
+            builder.setDescription("Du kannst sowas nur machen, wenn du in einem Voicechannel bist");
+            builder.setColor(Color.RED);
+            channel.sendMessage("Error").setEmbeds(builder.build()).queue();
+            return;
+        }
+        // In welchem Channel ist er (Nachjoinen)
+        // Queue des Controllers holen und durchmischeln
+        MusicController controller = Slashy.INSTANCE.playerManager.getController(audioChannel.getGuild().getIdLong());
+        
+        //Debugging
+        System.out.println("Queue wurde durchgemischt");
+        
+        // Liste Mischen
+        controller.getTrackqueue().shuffle();
+
+        // Bestätigungsnachricht
+        message.addReaction("U+1F44D").queue();
+    }
+}

--- a/src/main/java/SlashyBot/music/commands/SkipCommand.java
+++ b/src/main/java/SlashyBot/music/commands/SkipCommand.java
@@ -1,0 +1,53 @@
+package SlashyBot.music.commands;
+
+import SlashyBot.Slashy;
+import SlashyBot.commandManaging.commands.ServerCommand;
+import SlashyBot.music.MusicController;
+import com.sedmelluq.discord.lavaplayer.player.AudioPlayer;
+import java.awt.Color;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.AudioChannel;
+import net.dv8tion.jda.api.entities.GuildVoiceState;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.TextChannel;
+import net.dv8tion.jda.api.managers.AudioManager;
+
+public class SkipCommand implements ServerCommand {
+    @Override
+    public void performCommand(Member member, TextChannel channel, Message message) {
+        // Checken, ist Auftragsteller überhaupt in einen Voice State hat
+        GuildVoiceState state;
+        if ((state = member.getVoiceState()) == null) {
+            // Fehlernachricht zurück geben
+            // Wenn nicht, einfach befehl abbrechen
+            return;
+        }
+
+        // Checken, ist Auftragsteller überhaupt in einem Voice Channel
+        AudioChannel audioChannel;
+        if ((audioChannel = state.getChannel()) == null){
+            EmbedBuilder builder = new EmbedBuilder();
+            builder.setDescription("Du kannst sowas nur machen, wenn du in einem Voicechannel bist");
+            builder.setColor(Color.RED);
+            channel.sendMessage("Error").setEmbeds(builder.build()).queue();
+            return;
+        }
+        // In welchem Channel ist er (Nachjoinen)
+        // Player holen zum stoppen
+        MusicController
+            controller = Slashy.INSTANCE.playerManager.getController(audioChannel.getGuild().getIdLong());
+        AudioManager audioManager = audioChannel.getGuild().getAudioManager();
+        AudioPlayer player = controller.getPlayer();
+
+
+        // Debugging
+        System.out.println("Lied geskippt");
+
+        // Track anhalten, endTrack Event wird getriggered
+        player.stopTrack();
+
+        // Bestätigungsnachricht
+        message.addReaction("U+1F44C").queue();
+    }
+}

--- a/src/main/java/SlashyBot/music/commands/SkipCommand.java
+++ b/src/main/java/SlashyBot/music/commands/SkipCommand.java
@@ -33,7 +33,6 @@ public class SkipCommand implements ServerCommand {
             channel.sendMessage("Error").setEmbeds(builder.build()).queue();
             return;
         }
-        // In welchem Channel ist er (Nachjoinen)
         // Player holen zum stoppen
         MusicController
             controller = Slashy.INSTANCE.playerManager.getController(audioChannel.getGuild().getIdLong());

--- a/src/main/java/SlashyBot/music/commands/StopCommand.java
+++ b/src/main/java/SlashyBot/music/commands/StopCommand.java
@@ -36,7 +36,6 @@ public class StopCommand implements ServerCommand {
             channel.sendMessage("Error").setEmbeds(builder.build()).queue();
             return;
         }
-        // In welchem Channel ist er (Nachjoinen)
         // Player holen zum stoppen
         MusicController controller = Slashy.INSTANCE.playerManager.getController(audioChannel.getGuild().getIdLong());
         AudioManager audioManager = audioChannel.getGuild().getAudioManager();

--- a/src/main/java/SlashyBot/music/commands/StopCommand.java
+++ b/src/main/java/SlashyBot/music/commands/StopCommand.java
@@ -42,10 +42,18 @@ public class StopCommand implements ServerCommand {
         AudioManager audioManager = audioChannel.getGuild().getAudioManager();
         AudioPlayer player = controller.getPlayer();
 
+
+        // Debugging
+        System.out.println("Der Player wird gstoppt und die Queue geleert");
+        
         // Audio anhalten
         player.stopTrack();
         // Connection beenden
         audioManager.closeAudioConnection();
+
+        // Liste leeren
+        controller.clearQueue();
+
         // Abschiedsnachricht
         message.addReaction("U+1F44C").queue();
     }

--- a/src/main/java/SlashyBot/threading/SavingThread.java
+++ b/src/main/java/SlashyBot/threading/SavingThread.java
@@ -17,7 +17,7 @@ public class SavingThread extends ThreadModel{
     @Override
     protected void loop() {
         slashy.saveData();
-        System.out.println("saving committed");
+//        System.out.println("saving committed");
 
         try {
             Thread.sleep(INTERVALLTIME);


### PR DESCRIPTION
# Music-Bot Queuesystem
Die Musikfähigkeiten von Slashy wurde grundlegend erweitert und verbessert.
### modifizierte Befehle:
- `//play <url>`: Es können nun ganze Youtube Playlisten hinzugefügt werden. Außerdem werden neue Lieder in eine Warteschlange gepackt, wenn grade schon was läuft
   - Suche mit Suchbegriffen funktioniert auch schon bedingt. Es werden die Top 17 Suchergebnisse direkt in die Playlist geladen
### neu implementierte Befehle:
- `//skip`: Überspringt die aktuelle Wiedergabe
- `//shuffle`: Mischt die Aktuelle Warteschlange zufällig durch
## Ausblick
Es sollten jetzt noch Kleinigkeiten wie das Suchen mit Suchbegriffen gefixt werden.
Auch will ich noch optische Improvements machen. Dazu gehören:
- Feedback beim nutzen des Bots, wie Angabe was grade abgespielt wurde oder Reaktionen auf Befehle
- weitere Befehle, welche Informationen geben, über die aktuelle Wiedergabe und die Warteschlange